### PR TITLE
Hydra-admin-collections is now Fedora 4 compatible.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,7 @@ require 'engine_cart/rake_task'
 
 APP_ROOT = '.'
 require 'jettywrapper'
-JETTY_ZIP_BASENAME = 'fedora-4/master'
-Jettywrapper.url = "https://github.com/projecthydra/hydra-jetty/archive/#{JETTY_ZIP_BASENAME}.zip"
+Jettywrapper.hydra_jetty_version = "v8.1.1"
 
 require 'rspec/core/rake_task'
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ require 'engine_cart/rake_task'
 
 APP_ROOT = '.'
 require 'jettywrapper'
-JETTY_ZIP_BASENAME = 'master'
+JETTY_ZIP_BASENAME = 'fedora-4/master'
 Jettywrapper.url = "https://github.com/projecthydra/hydra-jetty/archive/#{JETTY_ZIP_BASENAME}.zip"
 
 require 'rspec/core/rake_task'

--- a/Rakefile
+++ b/Rakefile
@@ -9,8 +9,7 @@ require 'engine_cart/rake_task'
 
 APP_ROOT = '.'
 require 'jettywrapper'
-JETTY_ZIP_BASENAME = 'master'
-Jettywrapper.url = "https://github.com/projecthydra/hydra-jetty/archive/#{JETTY_ZIP_BASENAME}.zip"
+Jettywrapper.hydra_jetty_version = "v8.1.1"
 
 require 'rspec/core/rake_task'
 

--- a/app/models/concerns/hydra/admin/collections/associations.rb
+++ b/app/models/concerns/hydra/admin/collections/associations.rb
@@ -2,6 +2,6 @@ module Hydra::Admin::Collections::Associations
   extend ActiveSupport::Concern
   included do
     # TODO is there a way to make this property configurable?
-    has_many :members, class_name: 'ActiveFedora::Base', property: :is_member_of_collection
+    has_many :members, class_name: 'ActiveFedora::Base', predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection
   end
 end

--- a/app/models/concerns/hydra/admin/collections/metadata.rb
+++ b/app/models/concerns/hydra/admin/collections/metadata.rb
@@ -1,12 +1,13 @@
 module Hydra::Admin::Collections::Metadata
   extend ActiveSupport::Concern
   included do
-    has_metadata 'descMetadata', type: ActiveFedora::SimpleDatastream do |sds|
-      sds.field :name, :string
-      sds.field :description, :string
+    property :title, predicate: RDF::DC.title, multiple: false do |index|
+      index.as :stored_searchable
     end
-
-    has_attributes :description, :name, datastream: :descMetadata, multiple: false
+    property :description, predicate: RDF::DC.description, multiple: false do |index|
+      index.type :text
+      index.as :stored_searchable
+    end
   end
 end
 

--- a/app/models/concerns/hydra/admin/collections/metadata.rb
+++ b/app/models/concerns/hydra/admin/collections/metadata.rb
@@ -1,13 +1,12 @@
 module Hydra::Admin::Collections::Metadata
   extend ActiveSupport::Concern
   included do
-    property :title, predicate: RDF::DC.title, multiple: false do |index|
-      index.as :stored_searchable
+    has_metadata 'descMetadata', type: ActiveFedora::SimpleDatastream do |sds|
+      sds.field :name, :string
+      sds.field :description, :string
     end
-    property :description, predicate: RDF::DC.description, multiple: false do |index|
-      index.type :text
-      index.as :stored_searchable
-    end
+   
+    has_attributes :description, :name, datastream: :descMetadata, multiple: false
   end
 end
 

--- a/app/models/concerns/hydra/admin/collections/metadata.rb
+++ b/app/models/concerns/hydra/admin/collections/metadata.rb
@@ -5,7 +5,7 @@ module Hydra::Admin::Collections::Metadata
       sds.field :name, :string
       sds.field :description, :string
     end
-
+   
     has_attributes :description, :name, datastream: :descMetadata, multiple: false
   end
 end

--- a/app/models/concerns/hydra/admin/collections/rights.rb
+++ b/app/models/concerns/hydra/admin/collections/rights.rb
@@ -1,8 +1,4 @@
 module Hydra::Admin::Collections::Rights
   extend ActiveSupport::Concern
   include Hydra::AccessControls::Permissions
-  included do
-    # Default rights get copied onto new members.  This is an access template.
-    has_metadata 'defaultRights', type: Hydra::Admin::Collections::NonIndexedRights, autocreate: true
-  end
 end

--- a/app/models/datastreams/hydra/admin/collections/non_indexed_rights.rb
+++ b/app/models/datastreams/hydra/admin/collections/non_indexed_rights.rb
@@ -1,7 +1,0 @@
-module Hydra::Admin::Collections
-  class NonIndexedRights < Hydra::Datastream::RightsMetadata    
-    def to_solr(solr_doc=Hash.new)
-      return solr_doc
-    end
-  end
-end

--- a/hydra-admin-collections.gemspec
+++ b/hydra-admin-collections.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "hydra-head", "~> 6.4.0"
-  spec.add_dependency "active-fedora", "~> 6.7.0"
+  spec.add_dependency "hydra-head", "~> 9.0.1"
+  spec.add_dependency "active-fedora", "~> 9.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/hydra/admin/collections/active_fedora_ext.rb
+++ b/lib/hydra/admin/collections/active_fedora_ext.rb
@@ -6,7 +6,7 @@ module Hydra::Admin::Collections
     # @option args [String] :class_name ('Hydra::Admin::Collection') the class of the collection itself 
     # @option args [Symbol] :property (:is_member_of_collection) the symbol that points at the RDF predicate to use 
     def belongs_to_admin_collection(args={})
-      belongs_to args.fetch(:name, :collection), class_name: args.fetch(:class_name, 'Hydra::Admin::Collection'), property: args.fetch(:property, :is_member_of_collection)
+      belongs_to args.fetch(:name, :collection), class_name: args.fetch(:class_name, 'Hydra::Admin::Collection'), predicate: args.fetch(:predicate, ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection)
     end
   end
 end

--- a/lib/hydra/admin/collections/active_fedora_ext.rb
+++ b/lib/hydra/admin/collections/active_fedora_ext.rb
@@ -6,7 +6,7 @@ module Hydra::Admin::Collections
     # @option args [String] :class_name ('Hydra::Admin::Collection') the class of the collection itself 
     # @option args [Symbol] :property (:is_member_of_collection) the symbol that points at the RDF predicate to use 
     def belongs_to_admin_collection(args={})
-       belongs_to args.fetch(:name, :collection), class_name: args.fetch(:class_name, 'Hydra::Admin::Collection'), predicate: args.fetch(:predicate, ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection)
+      belongs_to args.fetch(:name, :collection), class_name: args.fetch(:class_name, 'Hydra::Admin::Collection'), predicate: args.fetch(:predicate, ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection)
     end
   end
 end

--- a/lib/hydra/admin/collections/active_fedora_ext.rb
+++ b/lib/hydra/admin/collections/active_fedora_ext.rb
@@ -6,7 +6,7 @@ module Hydra::Admin::Collections
     # @option args [String] :class_name ('Hydra::Admin::Collection') the class of the collection itself 
     # @option args [Symbol] :property (:is_member_of_collection) the symbol that points at the RDF predicate to use 
     def belongs_to_admin_collection(args={})
-      belongs_to args.fetch(:name, :collection), class_name: args.fetch(:class_name, 'Hydra::Admin::Collection'), property: args.fetch(:property, :is_member_of_collection)
+       belongs_to args.fetch(:name, :collection), class_name: args.fetch(:class_name, 'Hydra::Admin::Collection'), predicate: args.fetch(:predicate, ActiveFedora::RDF::Fcrepo::RelsExt.isMemberOfCollection)
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -23,7 +23,7 @@ describe Hydra::Admin::Collection do
     let!(:member3) { GenericFile.create!(collection: subject) }
 
     it "should hold many members" do
-      subject.members.should == [member1, member2, member3]
+      expect(subject.members).to eq [member1, member2, member3]
     end
   end
 
@@ -32,15 +32,17 @@ describe Hydra::Admin::Collection do
     expect(subject.edit_users).to eq ['frank', 'sarah']
   end
 
-  it "should have defaultRights" do
-    subject.defaultRights.permissions = {"person"=>{"maria"=>"read","marcus"=>"discover"}, "group" => {"registered" => 'read'}}
-    subject.defaultRights.individuals.should == {"maria"=>"read","marcus"=>"discover"}
+
+  it "should have many permissions" do
+    subject.permissions_attributes = [{ name: "public", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
+    expect(subject.edit_users).to eq ["joe_creator","calvin_collaborator"]
+    expect(subject.read_groups).to eq ["public"]
   end
 
 
-  it "should have a name" do
-    subject.name = "A Collection of Art"
-    expect(subject.name).to eq "A Collection of Art"
+  it "should have a title" do
+    subject.title = "A Collection of Art"
+    expect(subject.title).to eq "A Collection of Art"
   end
 
   it "should have a description" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -40,9 +40,9 @@ describe Hydra::Admin::Collection do
   end
 
 
-  it "should have a title" do
-    subject.title = "A Collection of Art"
-    expect(subject.title).to eq "A Collection of Art"
+  it "should have a name" do
+    subject.name = "A Collection of Art"
+    expect(subject.name).to eq "A Collection of Art"
   end
 
   it "should have a description" do

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -23,7 +23,7 @@ describe Hydra::Admin::Collection do
     let!(:member3) { GenericFile.create!(collection: subject) }
 
     it "should hold many members" do
-      subject.members.should == [member1, member2, member3]
+      expect(subject.members).to eq [member1, member2, member3]
     end
   end
 
@@ -32,9 +32,11 @@ describe Hydra::Admin::Collection do
     expect(subject.edit_users).to eq ['frank', 'sarah']
   end
 
-  it "should have defaultRights" do
-    subject.defaultRights.permissions = {"person"=>{"maria"=>"read","marcus"=>"discover"}, "group" => {"registered" => 'read'}}
-    subject.defaultRights.individuals.should == {"maria"=>"read","marcus"=>"discover"}
+
+  it "should have many permissions" do
+    subject.permissions_attributes = [{ name: "public", access: "read", type: "group" }, { name: "joe_creator", access: "edit", type: "person" }, { name: "calvin_collaborator", access: "edit", type: "person" }]
+    expect(subject.edit_users).to eq ["joe_creator","calvin_collaborator"]
+    expect(subject.read_groups).to eq ["public"]
   end
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,5 +6,5 @@ require 'engine_cart'
 EngineCart.load_application!
 # require 'rspec'
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
 end


### PR DESCRIPTION
Hydra::Admin::Collections now works with Fedora 4. 
There are a few changes, though:
- An Admin Collection can no longer have a name, since 'name' is a keyword in Fedora 4, instead it has a **title**.
- No more defaultRights since there isn't a RightsMetadata datastream (it still uses permissions, though).
